### PR TITLE
Install TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "types",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "types",
+  "version": "0.1.0",
+  "description": "A place for types",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guardian/types.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/guardian/types/issues"
+  },
+  "homepage": "https://github.com/guardian/types#readme",
+  "dependencies": {
+    "typescript": "^3.8.3"
+  }
+}


### PR DESCRIPTION
## Why?

We're defining these types in TypeScript.

I ran an `npm init` first to set up a `package.json`, please let me know if you think that's a bad idea or if there's a better option!

## Changes

- Ran `npm init` to get `package.json` set up
- Installed TypeScript
- Created `.gitignore` for node_modules
