### PR TITLE
Format and ColourScheme

### DIFF
--- a/ColourScheme.ts
+++ b/ColourScheme.ts
@@ -1,0 +1,51 @@
+// ----- Imports ----- //
+
+import { Format, Pillar, Design } from './Format';
+
+
+// ----- Types ----- //
+
+const enum ColourScheme {
+    News,
+    Opinion,
+    Sport,
+    Culture,
+    Lifestyle,
+    Labs,
+    SpecialReport,
+}
+
+
+// ----- Functions ----- //
+
+function fromFormat({ pillar, design }: Format): ColourScheme {
+    if (design === Design.Comment && pillar === Pillar.News) {
+        return ColourScheme.Opinion;
+    }
+
+    if (pillar === Pillar.Opinion) {
+        return ColourScheme.Opinion;
+    }
+
+    if (pillar === Pillar.Sport) {
+        return ColourScheme.Sport;
+    }
+
+    if (pillar === Pillar.Culture) {
+        return ColourScheme.Culture;
+    }
+
+    if (pillar === Pillar.Lifestyle) {
+        return ColourScheme.Lifestyle;
+    }
+
+    return ColourScheme.News;
+}
+
+
+// ----- Exports ----- //
+
+export {
+    ColourScheme,
+    fromFormat,
+}

--- a/Format.ts
+++ b/Format.ts
@@ -1,0 +1,47 @@
+// ----- Types ----- //
+
+const enum Pillar {
+    News,
+    Opinion,
+    Sport,
+    Culture,
+    Lifestyle,
+}
+
+const enum Design {
+    Article,
+    Media,
+    Review,
+    Analysis,
+    Comment,
+    Feature,
+    Live,
+    Recipe,
+    MatchReport,
+    Interview,
+    GuardianView,
+    Quiz,
+    AdvertisementFeature,
+}
+
+const enum Display {
+    Standard,
+    Immersive,
+    Showcase,
+}
+
+interface Format {
+    pillar: Pillar;
+    design: Design;
+    display: Display;
+}
+
+
+// ----- Exports ----- //
+
+export {
+    Pillar,
+    Design,
+    Display,
+    Format,
+}


### PR DESCRIPTION
## Why?

We are attempting to consolidate on a `Format` type to describe content. This adds that type and its components: `Pillar`, `Design` and `Display`. This is partially derived from the types currently in use in `apps-rendering`, as seen [here](https://github.com/guardian/apps-rendering/blob/0ce5a93fda2fc0cca9e45825a4889d4160f00cbb/src/item.ts#L56) and [here](https://github.com/guardian/apps-rendering/blob/0ce5a93fda2fc0cca9e45825a4889d4160f00cbb/src/pillar.ts#L10).

It also adds a new `ColourScheme` type and a way to derive that from `Format`. This derivation is limited at the moment, as we need access to tags to derive `Labs` and `SpecialReport`. We'll need to decide whether we want to import the `Tag` type from the Thrift definitions, or define a subset type for what we need here:

```ts
interface Tag = {
    type: string;
    id: string;
}
```

Don't know if this is what you were aiming for @oliverlloyd? Feel free to suggest changes!

## Changes

- Defined Pillar, Design and Display within Format
- Included function to derive ColourScheme from Format
