### PR TITLE
Derive Labs ColourScheme

### DIFF
--- a/ColourScheme.ts
+++ b/ColourScheme.ts
@@ -23,6 +23,10 @@ function fromFormat({ pillar, design }: Format): ColourScheme {
         return ColourScheme.Opinion;
     }
 
+    if (design === Design.AdvertisementFeature) {
+        return ColourScheme.Labs;
+    }
+
     if (pillar === Pillar.Opinion) {
         return ColourScheme.Opinion;
     }


### PR DESCRIPTION
## Why?

Advertisement features use the `Labs` colour scheme.

## Changes

- Applied `Labs` colour scheme for `Design.AdvertisementFeature`
