### PR TITLE
Add remaining display hints

### DIFF
--- a/Format.ts
+++ b/Format.ts
@@ -29,6 +29,9 @@ const enum Display {
     Standard,
     Immersive,
     Showcase,
+    NumberedList,
+    Column,
+    PhotoEssay
 }
 
 interface Format {

--- a/Format.ts
+++ b/Format.ts
@@ -30,8 +30,7 @@ const enum Display {
     Immersive,
     Showcase,
     NumberedList,
-    Column,
-    PhotoEssay
+    Column
 }
 
 interface Format {


### PR DESCRIPTION
I'm assuming all displayHint's should be in the `Display` enum?

Column: https://www.theguardian.com/world/2020/may/07/revealed-the-secret-report-that-gave-ministers-warning-of-care-home-coronavirus-crisis

NumberedList: https://www.theguardian.com/world/2020/mar/28/life-after-coronavirus-panic-buying-cocaine-drug-dealer-spaceman-therapist

PhotoEssay:https://www.theguardian.com/uk-news/2020/may/13/coronavirus-intensive-care-in-an-edinburgh-hospital-photo-essay