### PR TITLE
Result

### DIFF
--- a/option.ts
+++ b/option.ts
@@ -1,0 +1,104 @@
+// ----- Types ----- //
+
+const enum OptionKind {
+    Some,
+    None,
+}
+
+type Some<A> = {
+    kind: OptionKind.Some;
+    value: A;
+}
+
+type None = {
+    kind: OptionKind.None;
+}
+
+/**
+ * Represents a value that may or may not exist; it's either a Some or a None.
+ */
+type Option<A> = Some<A> | None;
+
+
+// ----- Constructors ----- //
+
+const some = <A>(a: A): Some<A> => ({ kind: OptionKind.Some, value: a });
+const none: None = { kind: OptionKind.None };
+
+/**
+ * Turns a value that may be `null` or `undefined` into an `Option`.
+ * If it's `null` or `undefined` the `Option` will be a `None`. If it's
+ * some other value the `Option` will be a `Some` "wrapping" that value.
+ * @param a The value that may be `null` or `undefined`
+ * @returns {Option<A>} An `Option`
+ */
+const fromNullable = <A>(a: A | null | undefined): Option<A> =>
+    a === null || a === undefined ? none : some(a);
+
+
+// ----- Functions ----- //
+
+/**
+ * Returns the value if `Some`, otherwise returns `a`. You can think of it
+ * as "unwrapping" the `Option`, getting you back a plain value
+ * @param a The value to fall back to if the `Option` is `None`
+ * @param optA The Option
+ * @returns {A} The value for a `Some`, `a` for a `None`
+ * @example
+ * const bylineOne = some('CP Scott');
+ * withDefault('Jane Smith')(bylineOne); // Returns 'CP Scott'
+ *
+ * const bylineTwo = none;
+ * withDefault('Jane Smith')(bylineTwo); // Returns 'Jane Smith'
+*/
+const withDefault = <A>(a: A) => (optA: Option<A>): A =>
+    optA.kind === OptionKind.Some ? optA.value : a;
+
+/**
+ * Applies a function to a `Some`, does nothing to a `None`.
+ * @param f The function to apply
+ * @param optA The Option
+ * @returns {Option<B>} A new `Option`
+ * @example
+ * const creditOne = some('Nicéphore Niépce');
+ * // Returns Some('Photograph: Nicéphore Niépce')
+ * map(name => `Photograph: ${name}`)(creditOne);
+ * 
+ * const creditTwo = none;
+ * map(name => `Photograph: ${name}`)(creditTwo); // Returns None
+ * 
+ * // All together
+ * compose(withDefault(''), map(name => `Photograph: ${name}`))(credit);
+ */
+const map = <A, B>(f: (a: A) => B) => (optA: Option<A>): Option<B> =>
+    optA.kind === OptionKind.Some ? some(f(optA.value)) : none;
+
+/**
+ * Like `map` but applies a function that *also* returns an `Option`.
+ * Then "unwraps" the result for you so you don't end up with
+ * `Option<Option<A>>`
+ * @param f The function to apply
+ * @param optA The Option
+ * @returns {Option<B>} A new `Option`
+ * @example
+ * type GetUser = number => Option<User>;
+ * type GetUserName = User => Option<string>;
+ * 
+ * const userId = 1;
+ * const username: Option<string> = compose(andThen(getUserName), getUser)(userId);
+ */
+const andThen = <A, B>(f: (a: A) => Option<B>) => (optA: Option<A>): Option<B> =>
+    optA.kind === OptionKind.Some ? f(optA.value) : none;
+
+
+// ----- Exports ----- //
+
+export {
+    Option,
+    some,
+    none,
+    fromNullable,
+    withDefault,
+    map,
+    andThen,
+};

--- a/result.ts
+++ b/result.ts
@@ -1,0 +1,146 @@
+// ----- Imports ----- //
+
+import { Option, some, none } from './option';
+
+
+// ----- Types ----- //
+
+const enum ResultKind {
+    Ok,
+    Err,
+}
+
+type Ok<A> = {
+    kind: ResultKind.Ok;
+    value: A;
+}
+
+type Err<E> = {
+    kind: ResultKind.Err;
+    err: E;
+}
+
+/**
+ * Represents either a value or an error; it's either an `Ok` or an `Err`.
+ */
+type Result<E, A> = Err<E> | Ok<A>;
+
+
+// ----- Constructors ----- //
+
+const ok = <A>(a: A): Ok<A> => ({ kind: ResultKind.Ok, value: a });
+const err = <E>(e: E): Err<E> => ({ kind: ResultKind.Err, err: e });
+
+/**
+ * Converts an operation that might throw into a `Result`
+ * @param f The operation that might throw
+ * @param error The error to return if the operation throws
+ */
+function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
+    try {
+        return ok(f());
+    } catch (_) {
+        return err(error);
+    }
+}
+
+
+// ----- Functions ----- //
+
+/**
+ * The method for turning a `Result<E, A>` into a plain value.
+ * If this is an `Err`, apply the first function to the error value and
+ * return the result. If this is an `Ok`, apply the second function to
+ * the value and return the result.
+ * @param f The function to apply if this is an `Err`
+ * @param g The function to apply if this is an `Ok`
+ * @param result The Result
+ * @example
+ * const flakyTaskResult: Result<string, number> = flakyTask(options);
+ * 
+ * either(
+ *     data => `We got the data! Here it is: ${data}`,
+ *     error => `Uh oh, an error: ${error}`,
+ * )(flakyTaskResult)
+ */
+const either = <E, A, C>(f: (e: E) => C, g: (a: A) => C) => (result: Result<E, A>): C =>
+    result.kind === ResultKind.Ok ? g(result.value) : f(result.err);
+
+/**
+ * The companion to `map`.
+ * Applies a function to the error in `Err`, does nothing to an `Ok`.
+ * @param f The function to apply if this is an `Err`
+ * @param result The Result
+ */
+const mapError = <E, F>(f: (e: E) => F) => <A>(result: Result<E, A>): Result<F, A> =>
+    result.kind === ResultKind.Err ? err(f(result.err)) : result;
+
+/**
+ * Converts a `Result<E, A>` into an `Option<A>`. If the result is an
+ * `Ok` this will be a `Some`, if the result is an `Err` this will be
+ * a `None`.
+ * @param result The Result
+ */
+const toOption = <E, A>(result: Result<E, A>): Option<A> =>
+    result.kind === ResultKind.Ok ? some(result.value) : none;
+
+/**
+ * Similar to `Option.map`.
+ * Applies a function to the value in an `Ok`, does nothing to an `Err`.
+ * @param f The function to apply if this is an `Ok`
+ * @param result The Result
+ */
+const map = <A, B>(f: (a: A) => B) => <E>(result: Result<E, A>): Result<E, B> =>
+    result.kind === ResultKind.Ok ? ok(f(result.value)) : result;
+
+/**
+ * Similar to `Option.andThen`. Applies to a `Result` a function that
+ * *also* returns a `Result`, and unwraps them to avoid nested `Result`s.
+ * Can be useful for stringing together operations that might fail.
+ * @example
+ * type RequestUser = number => Result<string, User>;
+ * type GetEmail = User => Result<string, string>;
+ * 
+ * // Request fails: Err('Network failure')
+ * // Request succeeds, problem accessing email: Err('Email field missing')
+ * // Both succeed: Ok('email_address')
+ * andThen(getEmail)(requestUser(id))
+ */
+const andThen = <E, A, B>(f: (a: A) => Result<E, B>) => (result: Result<E, A>): Result<E, B> =>
+    result.kind === ResultKind.Ok ? f(result.value) : result;
+
+/**
+ * The return type of the `partition` function
+ */
+type Partitioned<E, A> = { errs: E[]; oks: A[] };
+
+/**
+ * Takes a list of `Result`s and separates out the `Ok`s from the `Err`s.
+ * @param results A list of `Result`s
+ * @return {Partitioned} An object with two fields, one for the list of `Err`s
+ * and one for the list of `Ok`s
+ */
+const partition = <E, A>(results: Result<E, A>[]): Partitioned<E, A> =>
+    results.reduce(({ errs, oks }: Partitioned<E, A>, result) =>
+        either<E, A, Partitioned<E, A>>(
+            err => ({ errs: [ ...errs, err ], oks }),
+            ok => ({ errs, oks: [ ...oks, ok ] }),
+        )(result),
+        { errs: [], oks: [] },
+    );
+
+
+// ----- Exports ----- //
+
+export {
+    Result,
+    ok,
+    err,
+    fromUnsafe,
+    partition,
+    either,
+    mapError,
+    toOption,
+    map,
+    andThen,
+};


### PR DESCRIPTION
## What does this change?

Added an `Result` type and companion functions. This PR relies on #12 and is also a clone of the type that we've been using for some time in [`apps-rendering`](https://github.com/guardian/apps-rendering/blob/master/src/types/result.ts). I'm migrating it to this repo because I'd like to make use of it in [`liveblog-rendering`](https://github.com/guardian/liveblog-rendering) as well, and it may be useful for DCR if and when it starts to consume `liveblog-rendering`.

## Changes

- New `Result` type, consisting of `Ok` and `Err`
- `fromUnsafe` constructor to create a `Result` from a possible JavaScript exception
- `ok` and `err` convenience functions to create a `Result`
- `either`, `map`, `mapError`, `partition` and `andThen` functions for working with `Result`
- `toOption` function to convert a `Result` to an `Option`
