### PR TITLE
Export OptionKind From Option

### DIFF
--- a/option.ts
+++ b/option.ts
@@ -108,6 +108,7 @@ const andThen = <A, B>(f: (a: A) => Option<B>) => (optA: Option<A>): Option<B> =
 
 export {
     Option,
+    OptionKind,
     some,
     none,
     fromNullable,


### PR DESCRIPTION
## What does this change?

Exports the `OptionKind` enum from `option.ts` so that it can be used to narrow the types of `Option`s. For example:

```ts
switch (opt.kind) {
    case OptionKind.Some:
        return doStuff(opt.value);
    case OptionKind.None:
    default:
        return 'Nothing to do!';
}
```
