### PR TITLE
Export ResultKind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/types",
-  "version": "0.3.0",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/types",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A place for types",
   "main": "index.js",
   "scripts": {

--- a/result.ts
+++ b/result.ts
@@ -134,6 +134,7 @@ const partition = <E, A>(results: Result<E, A>[]): Partitioned<E, A> =>
 
 export {
     Result,
+    ResultKind,
     ok,
     err,
     fromUnsafe,


### PR DESCRIPTION
## Why?

To pattern match `Result`s, equivalent to the change for `Option` in #15.

## Changes

- Export `ResultKind` from `result.ts`
