### PR TITLE
Set isolatedModules to true

### DIFF
--- a/Format.ts
+++ b/Format.ts
@@ -1,6 +1,6 @@
 // ----- Types ----- //
 
-const enum Pillar {
+enum Pillar {
     News,
     Opinion,
     Sport,
@@ -8,7 +8,7 @@ const enum Pillar {
     Lifestyle,
 }
 
-const enum Design {
+enum Design {
     Article,
     Media,
     Review,
@@ -25,7 +25,7 @@ const enum Design {
     Interactive
 }
 
-const enum Display {
+enum Display {
     Standard,
     Immersive,
     Showcase,

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # types
+
 A place for types
+
+Use `yarn tsc` to check things before publishing.

--- a/option.ts
+++ b/option.ts
@@ -63,10 +63,10 @@ const withDefault = <A>(a: A) => (optA: Option<A>): A =>
  * const creditOne = some('Nicéphore Niépce');
  * // Returns Some('Photograph: Nicéphore Niépce')
  * map(name => `Photograph: ${name}`)(creditOne);
- * 
+ *
  * const creditTwo = none;
  * map(name => `Photograph: ${name}`)(creditTwo); // Returns None
- * 
+ *
  * // All together
  * compose(withDefault(''), map(name => `Photograph: ${name}`))(credit);
  */
@@ -96,7 +96,7 @@ const map2 = <A, B, C>(f: (a: A, b: B) => C) => (optA: Option<A>) => (optB: Opti
  * @example
  * type GetUser = number => Option<User>;
  * type GetUserName = User => Option<string>;
- * 
+ *
  * const userId = 1;
  * const username: Option<string> = compose(andThen(getUserName), getUser)(userId);
  */
@@ -107,7 +107,6 @@ const andThen = <A, B>(f: (a: A) => Option<B>) => (optA: Option<A>): Option<B> =
 // ----- Exports ----- //
 
 export {
-    Option,
     OptionKind,
     some,
     none,
@@ -117,3 +116,5 @@ export {
     map2,
     andThen,
 };
+
+export type { Option };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A place for types",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "tsc": "tsc"
   },
   "repository": {
     "type": "git",

--- a/result.ts
+++ b/result.ts
@@ -57,7 +57,7 @@ function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
  * @param result The Result
  * @example
  * const flakyTaskResult: Result<string, number> = flakyTask(options);
- * 
+ *
  * either(
  *     data => `We got the data! Here it is: ${data}`,
  *     error => `Uh oh, an error: ${error}`,
@@ -100,7 +100,7 @@ const map = <A, B>(f: (a: A) => B) => <E>(result: Result<E, A>): Result<E, B> =>
  * @example
  * type RequestUser = number => Result<string, User>;
  * type GetEmail = User => Result<string, string>;
- * 
+ *
  * // Request fails: Err('Network failure')
  * // Request succeeds, problem accessing email: Err('Email field missing')
  * // Both succeed: Ok('email_address')
@@ -123,8 +123,8 @@ type Partitioned<E, A> = { errs: E[]; oks: A[] };
 const partition = <E, A>(results: Result<E, A>[]): Partitioned<E, A> =>
     results.reduce(({ errs, oks }: Partitioned<E, A>, result) =>
         either<E, A, Partitioned<E, A>>(
-            err => ({ errs: [ ...errs, err ], oks }),
-            ok => ({ errs, oks: [ ...oks, ok ] }),
+            err => ({ errs: [...errs, err], oks }),
+            ok => ({ errs, oks: [...oks, ok] }),
         )(result),
         { errs: [], oks: [] },
     );
@@ -133,7 +133,6 @@ const partition = <E, A>(results: Result<E, A>[]): Partitioned<E, A> =>
 // ----- Exports ----- //
 
 export {
-    Result,
     ResultKind,
     ok,
     err,
@@ -145,3 +144,5 @@ export {
     map,
     andThen,
 };
+
+export type { Result }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "esnext",
+        "module": "esnext",
+        "outDir": "dist",
+        "strict": true,
+        "esModuleInterop": true,
+        "moduleResolution": "node",
+        "allowJs": false,
+        "skipLibCheck": true,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true
+    },
+    "include": ["*.ts"],
+    "exclude": ["*.test.tsx"]
+}


### PR DESCRIPTION
## What does this change?

https://www.typescriptlang.org/tsconfig#isolatedModules

As part of this, a full tsconfig.json file has been added.

## Why?

DCR has runtime errors using this library together with `atoms-rendering` when importing and using one of the const enums from `Format.ts`. This is because exporting const enums doesn't work unless all projects are using the Typescript compiler directly (rather than Babel for example).

The motivation is the improve interop with other projects. The flag will help us avoid using TS features that don't work well with the Babel Typescript compiler and related tools. See e.g.

https://ncjamieson.com/dont-export-const-enums/

## How to test

I've used `yarn link` to test this with atoms-rendering and DCR and it fixes the const enum errors I've been seeing.

## Downsides

Slightly less efficient at runtime because the enums are no longer just ints. But I really doubt that this should be a practical concern.
