### PR TITLE
Add Theme to Format type

### DIFF
--- a/Format.ts
+++ b/Format.ts
@@ -8,6 +8,12 @@ const enum Pillar {
     Lifestyle,
 }
 
+const enum Special {
+    SpecialReport,
+}
+
+type Theme = Pillar | Special;
+
 const enum Design {
     Article,
     Media,
@@ -34,7 +40,7 @@ const enum Display {
 }
 
 interface Format {
-    pillar: Pillar;
+    theme: Theme;
     design: Design;
     display: Display;
 }

--- a/Format.ts
+++ b/Format.ts
@@ -1,15 +1,15 @@
 // ----- Types ----- //
 
 const enum Pillar {
-    News,
-    Opinion,
-    Sport,
-    Culture,
-    Lifestyle,
+    News = 0,
+    Opinion = 1,
+    Sport = 2,
+    Culture = 3,
+    Lifestyle = 4,
 }
 
 const enum Special {
-    SpecialReport,
+    SpecialReport = 5,
 }
 
 type Theme = Pillar | Special;


### PR DESCRIPTION
## What does this change?
Add theme field to Format. Articles can have a pillar theme or a special report theme.

We looked into adding SpecialReport as a "Design Type" but it would conflict with some like Analysis articles.