### PR TITLE
Add types related to Ophan

### DIFF
--- a/ophan.ts
+++ b/ophan.ts
@@ -1,0 +1,99 @@
+// ----- Types ----- //
+
+/**
+ * an individual A/B test, structured for Ophan
+ */
+type OphanABEvent = {
+    variantName: string;
+    complete: string | boolean;
+    campaignCodes?: Array<string>;
+};
+
+/**
+ * the actual payload we send to Ophan: an object of OphanABEvents with test IDs as keys
+ */
+type OphanABPayload = {
+    abTestRegister: { [testId: string]: OphanABEvent };
+};
+
+type OphanProduct =
+    | "CONTRIBUTION"
+    | "RECURRING_CONTRIBUTION"
+    | "MEMBERSHIP_SUPPORTER"
+    | "MEMBERSHIP_PATRON"
+    | "MEMBERSHIP_PARTNER"
+    | "DIGITAL_SUBSCRIPTION"
+    | "PRINT_SUBSCRIPTION";
+
+type OphanAction =
+    | "INSERT"
+    | "VIEW"
+    | "EXPAND"
+    | "LIKE"
+    | "DISLIKE"
+    | "SUBSCRIBE"
+    | "ANSWER"
+    | "VOTE"
+    | "CLICK";
+
+type OphanComponentType =
+    | "READERS_QUESTIONS_ATOM"
+    | "QANDA_ATOM"
+    | "PROFILE_ATOM"
+    | "GUIDE_ATOM"
+    | "TIMELINE_ATOM"
+    | "NEWSLETTER_SUBSCRIPTION"
+    | "SURVEYS_QUESTIONS"
+    | "ACQUISITIONS_EPIC"
+    | "ACQUISITIONS_ENGAGEMENT_BANNER"
+    | "ACQUISITIONS_THANK_YOU_EPIC"
+    | "ACQUISITIONS_HEADER"
+    | "ACQUISITIONS_FOOTER"
+    | "ACQUISITIONS_INTERACTIVE_SLICE"
+    | "ACQUISITIONS_NUGGET"
+    | "ACQUISITIONS_STANDFIRST"
+    | "ACQUISITIONS_THRASHER"
+    | "ACQUISITIONS_EDITORIAL_LINK"
+    | "ACQUISITIONS_SUBSCRIPTIONS_BANNER"
+    | "ACQUISITIONS_OTHER"
+    | "SIGN_IN_GATE"
+    | "RETENTION_ENGAGEMENT_BANNER";
+
+type OphanComponent = {
+    componentType: OphanComponentType;
+    id?: string;
+    products?: Array<OphanProduct>;
+    campaignCode?: string;
+    labels?: Array<string>;
+};
+
+type OphanComponentEvent = {
+    component: OphanComponent;
+    action: OphanAction;
+    value?: string;
+    id?: string;
+    abTest?: {
+        name: string;
+        variant: string;
+    };
+};
+
+type TestMeta = {
+    abTestName: string;
+    abTestVariant: string;
+    campaignCode: string;
+    campaignId?: string;
+    componentType: OphanComponentType;
+    products?: OphanProduct[];
+};
+
+export {
+    OphanABEvent,
+    OphanABPayload,
+    OphanAction,
+    OphanComponent,
+    OphanComponentEvent,
+    OphanComponentType,
+    OphanProduct,
+    TestMeta,
+};


### PR DESCRIPTION
## What does this change?

This PR adds types related to Ophan (extracted from DCR). Currently these types are duplicated in a few different projects (DCR, frontend, ab-testing). This is a first step towards moving them to a single shareable location.

I think the ideal is probably that these types live in Ophan's tracker-js library. However I think that would be a more significant change and piece of work (it's not a TypeScript project so would require changes to the toolchain and build process). Moving these to `@guardian/types` will allow us to try out centralising these without too much commitment. If the pattern works well then a move from here to tracker-js in future might make sense.