### PR TITLE
export Special enum

### DIFF
--- a/Format.ts
+++ b/Format.ts
@@ -50,6 +50,7 @@ interface Format {
 
 export {
     Pillar,
+    Special,
     Theme,
     Design,
     Display,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/types",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/types",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A place for types",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What does this change?

Follow-up on #29.
Special is not exported, and therefore cannot be used as a value in `image-rendering`.

See https://github.com/guardian/image-rendering/pull/71.

## How can we measure success?

All the relevant types are exported.
