### PR TITLE
Version 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/types",
-  "version": "0.5.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/types",
-  "version": "0.5.2",
+  "version": "1.0.0",
   "description": "A place for types",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Why?

We've been using this library in a few different repos for a while (apps-rendering, image-rendering, atoms-rendering), and we brought the library into line with Guardian recommendations in #34. Time to jump to `v1.0.0`?

Will do a GitHub release following this merge.

## Changes

- Updated version to `1.0.0` in `package.json` and `package-lock.json`
