### PR TITLE
Added PhotoEssay design

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -29,6 +29,7 @@ const enum Design {
 	Quiz,
 	AdvertisementFeature,
 	Interactive,
+	PhotoEssay,
 }
 
 const enum Display {


### PR DESCRIPTION
# PhotoEssay design

## What?
This PR adds `PhotoEssay` as a new Design type.

## Why?
We want to adopt this library in DCR but in DCR we use `Design` as the way to denote that an article is of the type photo essay so we add it here to ensure these article types continue to work.

### Why use Design?
Using `Design` gives us a way to represent this content with very few changes and the approach has the flexibility to scale in future (Showcase Photo Essays?).

### Why not Pillar?
Photo essays can belong to different pillars. A news photo essay looks different to a sport photo essay

### Why not Display? 
Photo essays are, by convention, immersive, in frontend there is even some code that when it sees the `isPhotoEssay` flag it sets the article to be 'immersive', but this convention is not required. There's no reason that a photo essay could not be Showcase or even Standard and we want to support that. Furthermore, in design terms, PhotoEssay !== Immersive, an immersive photoessay is _different_ to a normal Immersive article so we need way to represent this.

Another reason to not use `Display` is if we created a new Display value of `PhotoEssay` then the layout code for this page would be virtually identical to Immersive articles (because of the convention above), creating code duplication. This duplication could be worked around by reusing the `ImmersiveLayout` file but this creates brittle, confusing logic.

