### PR TITLE
GuardianLabs design type

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -26,6 +26,7 @@ const enum Design {
 	MatchReport,
 	Interview,
 	GuardianView,
+	GuardianLabs,
 	Quiz,
 	AdvertisementFeature,
 	Interactive,


### PR DESCRIPTION
## What does this change?
Adds the `GuardianLabs` Design type

## Why?
This design type is [sent to DCR from CAPI](https://github.com/guardian/frontend/blob/e71dc1c521672b28399811c59331e0c2c713bf00/common/app/model/Formats.scala#L175) and is expected in our code. We don't actually branch on this value anywhere but we have a lot of [case statements](https://github.com/guardian/dotcom-rendering/blob/c04773a62909aedceff525fb5f146ff2fe1a838d/src/web/layouts/DecideLayout.tsx#L47) that pass it through ready for when we do add support for these types of articles.

In order for us to adopt the /types `Design` value in DCR we need this type present.