### PR TITLE
Labs Pillar

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -10,6 +10,7 @@ const enum Pillar {
 
 const enum Special {
 	SpecialReport = 5,
+	Labs = 6,
 }
 
 type Theme = Pillar | Special;


### PR DESCRIPTION
## What does this change?
This adds the `Labs` pillar value under the `Special` const enum.

## Why is labs a pillar?
There's an [established colour palette](https://github.com/guardian/source/blob/435d3ad1f20944ec8ae54b41b5711af5b630f780/src/core/foundations/src/index.ts#L41) in Souorce which is already exposed [in DCR](https://github.com/guardian/dotcom-rendering/blob/b04141341475ccc80b7d48bb0f2819ae52a472bd/src/amp/components/topMeta/PaidForBand.tsx#L9).

## What about GuardianLabs design type?
This is an [open question](https://github.com/guardian/types/pull/41). It could be we branch all of the changes required to support labs articles from just the Pillar value or we could use a combination of `Labs` for colour and `GuadianLabs` for design changes.