### PR TITLE
Don't export const enums

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/types",
-  "version": "1.2.0",
+  "version": "2.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/types",
-  "version": "1.2.0",
+  "version": "2.0.0-0",
   "description": "A place for types",
   "main": "dist/index.js",
   "scripts": {

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,6 +1,6 @@
 // ----- Types ----- //
 
-const enum Pillar {
+enum Pillar {
 	News = 0,
 	Opinion = 1,
 	Sport = 2,
@@ -8,14 +8,14 @@ const enum Pillar {
 	Lifestyle = 4,
 }
 
-const enum Special {
+enum Special {
 	SpecialReport = 5,
 	Labs = 6,
 }
 
 type Theme = Pillar | Special;
 
-const enum Design {
+enum Design {
 	Article,
 	Media,
 	Review,
@@ -33,7 +33,7 @@ const enum Design {
 	PhotoEssay,
 }
 
-const enum Display {
+enum Display {
 	Standard,
 	Immersive,
 	Showcase,

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,6 +1,6 @@
 // ----- Types ----- //
 
-const enum OptionKind {
+enum OptionKind {
 	Some,
 	None,
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -5,7 +5,7 @@ import { none, some } from './option';
 
 // ----- Types ----- //
 
-const enum ResultKind {
+enum ResultKind {
 	Ok,
 	Err,
 }

--- a/src/role.ts
+++ b/src/role.ts
@@ -1,6 +1,6 @@
 // ----- Types ----- //
 
-const enum Role {
+enum Role {
 	Standard,
 	Immersive,
 	Supporting,


### PR DESCRIPTION
## What does this change?
Replaces `const enum` with just `enum`. Closes https://github.com/guardian/types/issues/56

## Why
See https://github.com/guardian/types/issues/56 for more discussion