### PR TITLE
Remove AdvertisementFeature

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -28,7 +28,6 @@ const enum Design {
 	Interview,
 	GuardianView,
 	Quiz,
-	AdvertisementFeature,
 	Interactive,
 	PhotoEssay,
 }


### PR DESCRIPTION
## What does this change?
Removes the `AdvertisementFeature` Design property

## Why?
Because it is now replaced by the theme `Labs`. This `Labs` theme is sufficient to represent the design of these articles.