### PR TITLE
Added PrintShop

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -31,6 +31,7 @@ const enum Design {
 	AdvertisementFeature,
 	Interactive,
 	PhotoEssay,
+	PrintShop,
 }
 
 const enum Display {


### PR DESCRIPTION
## What does this change?
Adds the `PrintShop` Design type

## Why?
There are a series of articles classified as [Guardian Print Shop](https://www.theguardian.com/artanddesign/series/guardian-print-shop) articles. Unlike other series, these articles have their own design which is not represented in the `Format` model.

![Screenshot 2021-01-18 at 20 46 04](https://user-images.githubusercontent.com/1336821/104961429-360eb280-59ce-11eb-8fbe-6fe78d1f67cc.jpg)


Print shop articles are `Immersive` but they have no main media, instead they use the first element in the body as the 'main' image, typically setting the weighting of this image to `immersive` (but [not always](https://www.theguardian.com/artanddesign/2020/dec/11/buy-a-classic-sport-photograph-diego-maradona-forever-no-10)). Normally, the headline for an `Immersive` article is inverted and overlaid onto the main media but for Print Shop articles they expect the headline to sit above the first element, more akin to a normal article.

To accomodate these differences we had to create a [noMainMedia](https://github.com/guardian/dotcom-rendering/blob/eb7bbbb1e1c34384713b839c3344903481beb006/src/web/components/ArticleHeadline.tsx#L241) prop in DCR but this is a poor solution and does not allow us to use the [Editorial Palette](https://github.com/guardian/dotcom-rendering/pull/2378) to decide the headline colours.

`Design.PrintShop` would allow us to encapsulate these articles purely within the model

## What about David Squires?
Naturally, there is an exception. Some print shop articles are different, having the article meta always below the headline and showing the article title in the left column. These are currently rendered as `ng-interactives` but if the work was done to update Composer then we could support another deisgn, `Design.CartoonShop`?

![Screenshot 2021-01-18 at 20 51 11](https://user-images.githubusercontent.com/1336821/104967752-0cf51e80-59dc-11eb-86e2-5ee854c9fe8d.jpg)

