### PR TITLE
Rename Design.GuardianView To Design.Editorial

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -26,7 +26,7 @@ enum Design {
 	Recipe,
 	MatchReport,
 	Interview,
-	GuardianView,
+	Editorial,
 	Quiz,
 	Interactive,
 	PhotoEssay,


### PR DESCRIPTION
## Why?

We'd like to rename `Design.GuardianView` to `Design.Editorial`.

1. To keep its name consistent with how it's referred to elsewhere.
2. To keep it internally consistent with how other `Design`s are named (i.e. they're not prefixed with the word `Guardian`).

## Changes

- Rename `Design.GuardianView` to `Design.Editorial`
