### PR TITLE
Added Letter To Design

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -21,6 +21,7 @@ enum Design {
 	Review,
 	Analysis,
 	Comment,
+	Letter,
 	Feature,
 	Live,
 	Recipe,


### PR DESCRIPTION
## Why?

Although dotcom and apps give `Letter` and `Comment` the same design treatment, Editions has distinct designs for each. Therefore we need a way to differentiate between them in the model.

**Note:** `Letter` or `Letters`? The rest of the `Design` types are all singular which is why I picked `Letter` for now.

## Changes

- Added `Letter` to `Design`
