### PR TITLE
Added RETENTION_ENGAGEMENT_BANNER OphanComponentType

### DIFF
--- a/src/ophan.ts
+++ b/src/ophan.ts
@@ -58,7 +58,7 @@ type OphanComponentType =
 	| 'ACQUISITIONS_OTHER'
 	| 'SIGN_IN_GATE'
 	| 'RETENTION_ENGAGEMENT_BANNER'
-	| 'RETENTION_ENGAGEMENT_EPIC';
+	| 'RETENTION_EPIC';
 
 type OphanComponent = {
 	componentType: OphanComponentType;

--- a/src/ophan.ts
+++ b/src/ophan.ts
@@ -57,7 +57,8 @@ type OphanComponentType =
 	| 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
 	| 'ACQUISITIONS_OTHER'
 	| 'SIGN_IN_GATE'
-	| 'RETENTION_ENGAGEMENT_BANNER';
+	| 'RETENTION_ENGAGEMENT_BANNER'
+	| 'RETENTION_ENGAGEMENT_EPIC';
 
 type OphanComponent = {
 	componentType: OphanComponentType;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This adds the `RETENTION_EPIC` to `OphanComponentType`.

[A PR](https://github.com/guardian/ophan/pull/4046) is currently underway to add that type to `Ophan`.

The Epic will only be available on DCR and not Frontend as most eligible articles are now rendered by DCR.

## N.B
I managed to blunder into pushing straight to `main` while adding this change so it might be worth adding branch protection for `main` to the repo. That change is now reverted.

