### PR TITLE
Adding CLICK_TO_VIEW_EMBED_OVERLAY OphanComponentType

### DIFF
--- a/src/ophan.ts
+++ b/src/ophan.ts
@@ -57,7 +57,8 @@ type OphanComponentType =
 	| 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
 	| 'ACQUISITIONS_OTHER'
 	| 'SIGN_IN_GATE'
-	| 'RETENTION_ENGAGEMENT_BANNER';
+	| 'RETENTION_ENGAGEMENT_BANNER'
+	| 'CLICK_TO_VIEW_EMBED_OVERLAY';
 
 type OphanComponent = {
 	componentType: OphanComponentType;


### PR DESCRIPTION
This is to support sending ophan component events for the ClickToView component in DCR.

The click to view component is rendered as a place holder for third party embedded content, which could have ability to track user activity in guardian products. 

The overlay forces the users to click to consent to being tracked by the third party before being able to see the content. 

This change enables the tracking of that click event.

This reflects the changes made to ophan in this PR:

https://github.com/guardian/ophan/pull/4055
