### PR TITLE
Remove `Column` `Display` type from `Format`

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -40,7 +40,6 @@ enum Display {
 	Immersive,
 	Showcase,
 	NumberedList,
-	Column,
 }
 
 interface Format {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Removes the `Column` type from `Format.Display`. This type has been deprecated in favour of using `Showcase`.

