### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+⚠️ **Deprecation warning: This package will soon be migrated to [guardian/libs](https://github.com/guardian/libs) and will be archived. **
+
 # types
 
 A place for types


### PR DESCRIPTION
## What does this change?
Add deprecation warning

## Why?

- To make people aware of the change
- To clarify the relationship between `guardian/types` and `guardian/libs`