### PR TITLE
Add `Design.Obituary`

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -33,6 +33,7 @@ enum Design {
 	Interactive,
 	PhotoEssay,
 	PrintShop,
+	Obituary,
 }
 
 enum Display {


### PR DESCRIPTION
## Why?

There's some unique styling for obituaries on Editions that we'd like to capture via `Design`. It's possible we'll want unique styling on dotcom and apps too at some point.

## Changes

- Add `Design.Obituary`
