### PR TITLE
Un-deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-⚠️ **Deprecation warning: This package will soon be migrated to [guardian/libs](https://github.com/guardian/libs) and will be archived. **
-
 # types
 
 A place for types


### PR DESCRIPTION
## Why?

As described in #136, we planned to migrate everything in this repo to `@guardian/libs`. Several features have already been moved across (thanks @jamie-lynch!): https://github.com/guardian/libs/pull/212, https://github.com/guardian/libs/pull/220, https://github.com/guardian/libs/pull/221, https://github.com/guardian/libs/pull/222

Unfortunately, we've been unable to migrate everything - for more details see https://github.com/guardian/libs/pull/193. As a result, these features will have to stay in `@guardian/types` so they can be consumed by the projects that use them, receive updates and bug fixes etc.. Therefore we're not in a position to deprecate the project for now 😔.

## Changes

- Remove deprecation warning from README
