### PR TITLE
Added InteractiveFullWidth to Display Hints obj

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -42,6 +42,7 @@ enum Display {
 	Immersive,
 	Showcase,
 	NumberedList,
+	InteractiveFullWidth,
 }
 
 interface Format {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We are creating a new DCR template for full-width interactives, essentially combining the 'immersive' style header with the 'interactives' style body. This PR is updating the type so it can be used in DCR and on Composer.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
There are no live articles of this type created yet.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Success would look like using this template and keeping TypeScript happy in DCR.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This is easily revertible if it causes any unforeseen problems

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
NA

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->
NA

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
